### PR TITLE
Move demo hub to use cilogon directly

### DIFF
--- a/config/clusters/2i2c/cluster.yaml
+++ b/config/clusters/2i2c/cluster.yaml
@@ -43,13 +43,12 @@ hubs:
     domain: demo.2i2c.cloud
     helm_chart: basehub
     auth0:
-      # connection update? Also ensure the basehub Helm chart is provided a
-      # matching value for jupyterhub.custom.2i2c.add_staff_user_ids_of_type!
-      connection: CILogon
+      enabled: false
     helm_chart_values_files:
       # The order in which you list files here is the order the will be passed
       # to the helm upgrade command in, and that has meaning. Please check
       # that you intend for these files to be applied in this order.
+      - enc-demo.secret.values.yaml
       - demo.values.yaml
   - name: ohw
     display_name: "Ocean Hack Week"

--- a/config/clusters/2i2c/demo.values.yaml
+++ b/config/clusters/2i2c/demo.values.yaml
@@ -20,7 +20,14 @@ jupyterhub:
           url: https://2i2c.org
   hub:
     config:
+      JupyterHub:
+        authenticator_class: cilogon
       Authenticator:
         # We do not define allowed_users here since only usernames matching this regex will be allowed to login into the hub.
         # Ref: https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.username_pattern
         username_pattern: '^(.+@2i2c\.org|.+@rmbl\.org|deployment-service-check)$'
+      CILogonAuthenticator:
+        oauth_callback_url: https://demo.2i2c.cloud/hub/oauth_callback
+        username_claim: email
+        allowed_idps:
+          - "2i2c.org"

--- a/config/clusters/2i2c/demo.values.yaml
+++ b/config/clusters/2i2c/demo.values.yaml
@@ -26,7 +26,7 @@ jupyterhub:
         # We do not define allowed_users here since only usernames matching this regex will be allowed to login into the hub.
         # Ref: https://jupyterhub.readthedocs.io/en/stable/api/auth.html#jupyterhub.auth.Authenticator.username_pattern
         username_pattern: '^(.+@2i2c\.org|.+@rmbl\.org|deployment-service-check)$'
-      CILogonAuthenticator:
+      CILogonOAuthenticator:
         oauth_callback_url: https://demo.2i2c.cloud/hub/oauth_callback
         username_claim: email
         allowed_idps:

--- a/config/clusters/2i2c/enc-demo.secret.values.yaml
+++ b/config/clusters/2i2c/enc-demo.secret.values.yaml
@@ -1,0 +1,20 @@
+jupyterhub:
+    hub:
+        config:
+            CILogonOAuthenticator:
+                client_id: ENC[AES256_GCM,data:I2OU6vxq+1MH1xjk5Zy4sVjFtMdgsOgG7lYa0UKJRAaG8csBnXIUi69yHJkkBojvGHBQ,iv:LV8iaQFVBr/iotKhFpilLIM1biVQlDLDJrZuV9IQDA8=,tag:ztZxAQZY+25qmUFfvN5w7A==,type:str]
+                client_secret: ENC[AES256_GCM,data:+fI/SCEsygTP6sQDcybSrpd4IO6KhpiKzNI59+C/mFRF4TNas7+zejRuzYVzJAKTjkEL1NIOek7DNLj47OcBL9Mm5iYyJM3f4gSImUo0QYLf0hnWMOA=,iv:GS2I3kv0IvOVDZht87oTT7LaWswXWwot95R2XWAbKBk=,tag:gI8fVcfLku52wYRHq9/kqQ==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/two-eye-two-see/locations/global/keyRings/sops-keys/cryptoKeys/similar-hubs
+          created_at: "2022-03-23T22:30:17Z"
+          enc: CiQA4OM7eIjffZKhqikREKUP2NJFoQ430IThTbFbNkrkPcPA++USSQDm5XgW0KL4+aPX+H0Xg0g9Y293y/8SEpifqE1T8On8Na0Phf6AMlg99x35lF1Sc9rTmnuBftzMaZ6YfsW3IVOwj+7fIbMuNWw=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-03-23T22:30:18Z"
+    mac: ENC[AES256_GCM,data:KipPDtFhkpA1DR+T2tEwqsRb2rAxg5woOLbl4tB75DWhQ4cSr2ne7EoHuNRs7GCJh0KZ19Sh5wu5ujpUQp3BlhUW/dj5h1W8f00e+T5RoroNU2VIWoG+C5Utgb84h6XLjz0IqPY9Z7TgWJcY6TTYJMF59DxUdyjhfWM3oSUGf2I=,iv:eGdldOja6bMbqrLEh/i6aaE20KOJ/Im626Ht22BOtT8=,tag:82paRer+fGTIqrJdjJEOWg==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1


### PR DESCRIPTION
This doesn't actually work, I get a `500` error after logging in. The following is in the hub logs:

```
[I 2022-03-23 22:55:48.225 JupyterHub log:189] 302 GET /hub/ -> /hub/login?next=%2Fhub%2F (@10.128.0.27) 0.83ms
[I 2022-03-23 22:55:48.340 JupyterHub log:189] 200 GET /hub/login?next=%2Fhub%2F (@10.128.0.27) 39.18ms
[I 2022-03-23 22:55:49.874 JupyterHub oauth2:111] OAuth redirect: 'https://demo.2i2c.cloud/hub/oauth_callback'
[I 2022-03-23 22:55:49.875 JupyterHub log:189] 302 GET /hub/oauth_login?next=%2Fhub%2F -> https://cilogon.org/authorize?response_type=code&redirect_uri=https%3A%2F%2Fdemo.2i2c.cloud%2Fhub%2Foauth_callback&client_id=cilogon%3A%2Fclient_id%2F37491535cff9060eb37f4cf4f0f93175&state=[secret]&scope=openid+email+org.cilogon.userinfo (@10.128.0.27) 2.24ms
[E 2022-03-23 22:55:52.508 JupyterHub oauth2:389] Error fetching 400 POST https://cilogon.org/oauth2/token: {
     "error": "invalid_request",
     "error_description": "Attempt to use alternate redirect uri rejected."
    }
[E 2022-03-23 22:55:52.508 JupyterHub web:1789] Uncaught exception GET /hub/oauth_callback?code=<secret>&state=<secret> (10.128.0.27)
    HTTPServerRequest(protocol='https', host='demo.2i2c.cloud', method='GET', uri='/hub/oauth_callback?code=<secret>&state=<secret>', version='HTTP/1.1', remote_ip='10.128.0.27')
    Traceback (most recent call last):
      File "/usr/local/lib/python3.8/dist-packages/tornado/web.py", line 1704, in _execute
        result = await result
      File "/usr/local/lib/python3.8/dist-packages/oauthenticator/oauth2.py", line 231, in get
        user = await self.login_user()
      File "/usr/local/lib/python3.8/dist-packages/jupyterhub/handlers/base.py", line 754, in login_user
        authenticated = await self.authenticate(data)
      File "/usr/local/lib/python3.8/dist-packages/jupyterhub/auth.py", line 469, in get_authenticated_user
        authenticated = await maybe_future(self.authenticate(handler, data))
      File "/usr/local/lib/python3.8/dist-packages/oauthenticator/cilogon.py", line 160, in authenticate
        token_response = await self.fetch(req)
      File "/usr/local/lib/python3.8/dist-packages/oauthenticator/oauth2.py", line 390, in fetch
        raise e
      File "/usr/local/lib/python3.8/dist-packages/oauthenticator/oauth2.py", line 369, in fetch
        resp = await self.http_client.fetch(req, **kwargs)
    tornado.httpclient.HTTPClientError: HTTP 400: Bad Request
    
[E 2022-03-23 22:55:52.535 JupyterHub log:181] {
      "Cookie": "oauthenticator-state=[secret]",
      "Sec-Fetch-User": "?1",
      "Sec-Fetch-Site": "cross-site",
      "Sec-Fetch-Mode": "navigate",
      "Sec-Fetch-Dest": "document",
      "Upgrade-Insecure-Requests": "1",
      "Referer": "https://cilogon.org/",
      "Accept-Encoding": "gzip, deflate, br",
      "Accept-Language": "en-US,en;q=0.5",
      "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
      "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:98.0) Gecko/20100101 Firefox/98.0",
      "X-Scheme": "https",
      "X-Forwarded-Scheme": "https",
      "X-Forwarded-Proto": "https,http",
      "X-Forwarded-Port": "443,80",
      "X-Forwarded-Host": "demo.2i2c.cloud",
      "X-Forwarded-For": "10.128.0.27,::ffff:10.0.1.23",
      "X-Real-Ip": "10.128.0.27",
      "X-Request-Id": "e588b76e2e3431b55e4ed83e590eedb5",
      "Host": "demo.2i2c.cloud",
      "Connection": "close"
    }
[E 2022-03-23 22:55:52.535 JupyterHub log:189] 500 GET /hub/oauth_callback?code=[secret]&state=[secret] (@10.128.0.27) 201.60ms
[I 2022-03-23 22:56:29.475 JupyterHub log:189] 200 GET /hub/metrics (@10.0.2.212) 5.22ms
```

The particular error seems to be `Attempt to use alternate redirect uri rejected.`. However, the config is correct from what I can tell. The `oauth_callback_url` is set to https://demo.2i2c.cloud/hub/oauth_callback, and that's what I get when looking at cilogon as well

```
$ python3 ./deployer/cilogon_app.py  get  2i2c demo
....
`'redirect_uris': ['https://demo.2i2c.cloud/hub/oauth_callback']`
```

In fact, in the URL the error is coming through from, you can see that callback_url is set to `https%3A%2F%2Fdemo.2i2c.cloud%2Fhub%2Foauth_callback`, which decodes to `https://demo.2i2c.cloud/hub/oauth_callback`, which is what we have registered! 

This config also seems to closely match what we have with `dask-staging`, and deploying *that* does seem to work.
