### PR TITLE
Remove allowed_idps for demo hub

### DIFF
--- a/config/clusters/2i2c/demo.values.yaml
+++ b/config/clusters/2i2c/demo.values.yaml
@@ -29,5 +29,3 @@ jupyterhub:
       CILogonOAuthenticator:
         oauth_callback_url: https://demo.2i2c.cloud/hub/oauth_callback
         username_claim: email
-        allowed_idps:
-          - "2i2c.org"


### PR DESCRIPTION
Continue to rely on username_pattern right now as we
figure out how to use IDPs