### PR TITLE
Remove CILogonOAuthenticator default scopes

### DIFF
--- a/helm-charts/basehub/values.yaml
+++ b/helm-charts/basehub/values.yaml
@@ -244,14 +244,6 @@ jupyterhub:
                 matchLabels:
                   app.kubernetes.io/component: traefik
   hub:
-    config:
-      # Default options for CILogonOAuthenticator, for hubs where it is enabled
-      CILogonOAuthenticator:
-        scope:
-          - openid
-          - email
-          - org.cilogon.userinfo
-
     extraFiles:
       configurator-schema-default:
         mountPath: /usr/local/etc/jupyterhub-configurator/00-default.schema.json


### PR DESCRIPTION
These are already actually set in the base CILogonOAuthenticator
itself! https://github.com/jupyterhub/oauthenticator/blob/8c1cf0c616d5e19d1f93238673f17db2daf57fa0/oauthenticator/cilogon.py#L69